### PR TITLE
Fix/#41 - Remove *::after and *::before pseudo class selectors from typography

### DIFF
--- a/packages/opc-styles/package-lock.json
+++ b/packages/opc-styles/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "opc-styles",
-  "version": "0.0.1",
+  "version": "0.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/opc-styles/package.json
+++ b/packages/opc-styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@one-platform/opc-styles",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "This packages contains the all common styles which are important to get #### started with any component which includes global variables, colors, common mixin",
   "main": "opc-styles.scss",
   "scripts": {

--- a/packages/opc-styles/typography/_base.scss
+++ b/packages/opc-styles/typography/_base.scss
@@ -5,9 +5,7 @@
 }
 
 // NORMALIZE
-*,
-*::before,
-*::after {
+* {
   box-sizing: border-box;
   font-family: var(--opc-global--Font-Family, 'Red Hat Text');
 }


### PR DESCRIPTION


### Resolves #41 

# Explain the feature/fix

Removed *::after and *::before default font styles

## Does this PR introduce a breaking change

No


### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [ ] Does the change have appropriate unit tests?
- [x] Did tests pass?
- [ ] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code
- [ ] I have documented my code, particularly in areas like todo, complex logic, quick fix, temporary patch, etc.
#### If it is a new component
- [ ] Does your component follow One Platform style guidelines?
- [ ] Does your component web accessibility standards? [Helper Doc](https://www.w3.org/TR/wai-aria-1.1/)
- [ ] Does your component support desktop screen sizes (350px, 720px, 1150px ,1920px)
#### Browsers you have tested in
- [ ] Latest two versions of Mozilla Firefox and Google Chrome supported by Red Hat Enterprise Linux distribution
- [ ] Google Chrome [Latest 2 versions]
- [ ] Mozilla Firefox [Latest 2 versions]
- [ ] Microsoft Edge [Latest 2 versions]
- [ ] Apple Safari [Latest 2 versions]
- [ ] Microsoft Internet Explorer 11
