### PR TITLE
fix(#54) - Bump up opc-header version to publish on npm

### DIFF
--- a/packages/opc-header/package-lock.json
+++ b/packages/opc-header/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@one-platform/opc-header",
-  "version": "0.0.1-prerelease",
+  "version": "0.0.2-prerelease",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/opc-header/package.json
+++ b/packages/opc-header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@one-platform/opc-header",
-  "version": "0.0.1-prerelease",
+  "version": "0.0.2-prerelease",
   "description": "A web component based on Lit Element for Red Hat One Platform Header",
   "scripts": {
     "dev": "webpack-dev-server --open",


### PR DESCRIPTION


### Resolves #54 

# Explain the feature/fix

Bumped the minor version

## Does this PR introduce a breaking change

No
