### PR TITLE
fix(#163) - Op-Component Library generator is failing due to the webpack upgrade

### DIFF
--- a/generator/generator-opc-generator/generators/app/templates/package.json
+++ b/generator/generator-opc-generator/generators/app/templates/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "dev": "webpack serve",
     "build": "webpack --mode production",
-    "start": "webpack-dev-server",
     "test:debug": "npm run build && DEBUG_MODE=1 jest --verbose=true"
   },
   "publishConfig": {

--- a/generator/generator-opc-generator/generators/app/templates/package.json
+++ b/generator/generator-opc-generator/generators/app/templates/package.json
@@ -3,10 +3,9 @@
   "version": "0.0.1",
   "description": "A simple web component built in javascript and lit",
   "scripts": {
-    "dev": "webpack-dev-server --open",
+    "dev": "webpack serve",
     "build": "webpack --mode production",
     "start": "webpack-dev-server",
-    "test": "npm run build && jest --verbose=true",
     "test:debug": "npm run build && DEBUG_MODE=1 jest --verbose=true"
   },
   "publishConfig": {

--- a/generator/generator-opc-generator/generators/app/templates/webpack.config.js
+++ b/generator/generator-opc-generator/generators/app/templates/webpack.config.js
@@ -5,6 +5,7 @@ module.exports = {
     mode: 'development',
     devServer: {
         contentBase: path.join(__dirname, 'dist'),
+        open: true,
         compress: true,
         port: 4200,
     },


### PR DESCRIPTION

### Resolves #163 

# Explain the feature/fix

Fixed generator with changing webpack-dev-server to webpack serve

## Does this PR introduce a breaking change

No
