### PR TITLE
Dependency update lit 2.0 for opc-header

### DIFF
--- a/packages/opc-header/package-lock.json
+++ b/packages/opc-header/package-lock.json
@@ -1278,6 +1278,16 @@
         "chalk": "^3.0.0"
       }
     },
+    "@lit/reactive-element": {
+      "version": "1.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.0.0-rc.2.tgz",
+      "integrity": "sha512-cujeIl5Ei8FC7UHf4/4Q3bRJOtdTe1vpJV/JEBYCggedmQ+2P8A2oz7eE+Vxi6OJ4nc0X+KZxXnBoH4QrEbmEQ=="
+    },
+    "@one-platform/opc-styles": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@one-platform/opc-styles/-/opc-styles-0.0.5.tgz",
+      "integrity": "sha512-/FeIXDx0KRsH+hrvOyB1mvI1XzQt7a1Nc8Q3WXQ84LD9UJp4OsF9jjqk5/AvrW90+gBlhhchWUJ8PtcQFxVhAg=="
+    },
     "@patternfly/patternfly": {
       "version": "4.103.6",
       "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-4.103.6.tgz",
@@ -1502,6 +1512,11 @@
       "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.6.tgz",
       "integrity": "sha512-W+bw9ds02rAQaMvaLYxAbJ6cvguW/iJXNT6lTssS1ps6QdrMKttqEAMEG/b5CR8TZl3/L7/lH0ZV5nNR1LXikA==",
       "dev": true
+    },
+    "@types/trusted-types": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-1.0.6.tgz",
+      "integrity": "sha512-230RC8sFeHoT6sSUlRO6a8cAnclO06eeiq1QDfiv2FGCLWFvvERWgwIQD4FWqD9A69BN7Lzee4OXwoMVnnsWDw=="
     },
     "@types/uglify-js": {
       "version": "3.9.3",
@@ -9608,6 +9623,35 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
       "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
       "dev": true
+    },
+    "lit": {
+      "version": "2.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.0.0-rc.2.tgz",
+      "integrity": "sha512-BOCuoJR04WaTV8UqTKk09cNcQA10Aq2LCcBOiHuF7TzWH5RNDsbCBP5QM9sLBSotGTXbDug/gFO08jq6TbyEtw==",
+      "requires": {
+        "@lit/reactive-element": "^1.0.0-rc.2",
+        "lit-element": "^3.0.0-rc.2",
+        "lit-html": "^2.0.0-rc.3"
+      },
+      "dependencies": {
+        "lit-element": {
+          "version": "3.0.0-rc.2",
+          "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.0.0-rc.2.tgz",
+          "integrity": "sha512-2Z7DabJ3b5K+p5073vFjMODoaWqy5PIaI4y6ADKm+fCGc8OnX9fU9dMoUEBZjFpd/bEFR9PBp050tUtBnT9XTQ==",
+          "requires": {
+            "@lit/reactive-element": "^1.0.0-rc.2",
+            "lit-html": "^2.0.0-rc.3"
+          }
+        },
+        "lit-html": {
+          "version": "2.0.0-rc.3",
+          "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.0.0-rc.3.tgz",
+          "integrity": "sha512-Y6P8LlAyQuqvzq6l/Nc4z5/P5M/rVLYKQIRxcNwSuGajK0g4kbcBFQqZmgvqKG+ak+dHZjfm2HUw9TF5N/pkCw==",
+          "requires": {
+            "@types/trusted-types": "^1.0.1"
+          }
+        }
+      }
     },
     "lit-element": {
       "version": "2.5.1",

--- a/packages/opc-header/package.json
+++ b/packages/opc-header/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@one-platform/opc-styles": "0.0.5",
     "@patternfly/patternfly": "4.103.6",
-    "lit-element": "2.5.1",
-    "lit-html": "1.4.1"
+    "lit": "^2.0.0-rc.2",
+    "lit-element": "2.5.1"
   }
 }


### PR DESCRIPTION
### Resolves #342 

# Explain the feature/fix

- Remove lit-html and add lit 2.0

## Does this PR introduce a breaking change

No

## Screenshots



### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Does the change have appropriate unit tests?
- [x] Did tests pass?
- [x] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code
- [x] I have documented my code, particularly in areas like todo, complex logic, quick fix, temporary patch, etc.
#### If it is a new component
- [x] Does your component follow One Platform style guidelines?
- [x] Does your component web accessibility standards? [Helper Doc](https://www.w3.org/TR/wai-aria-1.1/)
- [x] Does your component support desktop screen sizes (350px, 720px, 1150px ,1920px)
#### Browsers you have tested in
- [x] Latest two versions of Mozilla Firefox and Google Chrome supported by Red Hat Enterprise Linux distribution
- [x] Google Chrome [Latest 2 versions]
- [x] Mozilla Firefox [Latest 2 versions]
- [x] Microsoft Edge [Latest 2 versions]
- [x] Apple Safari [Latest 2 versions]
- [x] Microsoft Internet Explorer 11
