### PR TITLE
replaces @internalProperty() to @state

### DIFF
--- a/packages/opc-comment-input/package-lock.json
+++ b/packages/opc-comment-input/package-lock.json
@@ -7699,19 +7699,6 @@
         }
       }
     },
-    "lit-element": {
-      "version": "2.4.0",
-      "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/lit-element/-/lit-element-2.4.0.tgz",
-      "integrity": "sha512-pBGLglxyhq/Prk2H91nA0KByq/hx/wssJBQFiYqXhGDvEnY31PRGYf1RglVzyLeRysu0IHm2K0P196uLLWmwFg==",
-      "requires": {
-        "lit-html": "^1.1.1"
-      }
-    },
-    "lit-html": {
-      "version": "1.3.0",
-      "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/lit-html/-/lit-html-1.3.0.tgz",
-      "integrity": "sha512-0Q1bwmaFH9O14vycPHw8C/IeHMk/uSDldVLIefu/kfbTBGIc44KGH6A8p1bDfxUfHdc8q6Ct7kQklWoHgr4t1Q=="
-    },
     "lit-scss-loader": {
       "version": "1.0.1",
       "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/lit-scss-loader/-/lit-scss-loader-1.0.1.tgz",

--- a/packages/opc-comment-input/package.json
+++ b/packages/opc-comment-input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@one-platform/opc-comment-input",
-  "version": "0.0.1-prerelease",
+  "version": "0.0.2-prerelease",
   "description": "A standardized web component based on Lit Element for Red Hat One Platform to use as a comment input component.",
   "scripts": {
     "dev": "webpack serve",
@@ -39,7 +39,6 @@
   },
   "dependencies": {
     "@one-platform/opc-styles": "0.0.5",
-    "lit": "^2.0.0-rc.2",
-    "lit-element": "2.4.0"
+    "lit": "^2.0.0-rc.2"
   }
 }

--- a/packages/opc-comment-input/src/opc-comment-input.ts
+++ b/packages/opc-comment-input/src/opc-comment-input.ts
@@ -1,5 +1,5 @@
-import { LitElement, html, property, customElement, query } from 'lit-element';
-import { state } from 'lit/decorators.js';
+import { LitElement, html, } from 'lit';
+import { state, property, customElement, query } from 'lit/decorators.js';
 import style  from './opc-comment-input.scss';
 
 @customElement('opc-comment-input')

--- a/packages/opc-comment-input/src/opc-comment-input.ts
+++ b/packages/opc-comment-input/src/opc-comment-input.ts
@@ -1,4 +1,5 @@
-import { LitElement, html, property, customElement, query, internalProperty } from 'lit-element';
+import { LitElement, html, property, customElement, query } from 'lit-element';
+import { state } from 'lit/decorators.js';
 import style  from './opc-comment-input.scss';
 
 @customElement('opc-comment-input')
@@ -6,7 +7,7 @@ export class CommentInput extends LitElement {
   @property({type: String})
   placeholder = 'Type your comment';
 
-  @internalProperty()
+  @state()
   protected commentText = '';
 
   @query('textarea')


### PR DESCRIPTION
With new "Lit" dependency.... the `internalProperty` decorater is renamed to `state` and bumped the package version.