### PR TITLE
feat(1109):  opc-nav's search component partitoned to another component 

### DIFF
--- a/packages/opc-nav/README.md
+++ b/packages/opc-nav/README.md
@@ -39,6 +39,7 @@ It is a mandatory slot component that contains the product logo, positioned at t
 ```html
 <opc-nav>
   <img slot="opc-nav-logo" />
+  <opc-nav-search slot="opc-nav-search"></opc-nav-search>
 </opc-nav>
 ```
 
@@ -61,6 +62,7 @@ Links are the quick reference links for easy navigation, positioned after the lo
 ```html
 <opc-nav>
   <img slot="opc-nav-logo" src="" alt="logo" />
+  <opc-nav-search slot="opc-nav-search"></opc-nav-search>
 </opc-nav>
 ```
 
@@ -80,13 +82,11 @@ document.querySelector('opc-nav').links = links;
 
 <!-- 3. opc-nav with buttons -->
 <details>
-<summary>opc-nav with search and nav buttons</summary>
+<summary>opc-nav with nav buttons</summary>
 
 ## Details
 
-The search bar component helps users to search for information. It is customizable by using the slot `opc-nav-search` . It can be removed by the attribute `isSearchHidden` with the value true.
-
-The nav buttons, enable utility actions that enhance the user experience. By default, opc-nav provids two buttons with there corresponding events. Menu buttons can be replaced with the slot `opc-nav-btn`. Icon buttons with size of 60px are prefered.
+The nav buttons, enable utility actions that enhance the user experience. By default, opc-nav provides two buttons with there corresponding events. Menu buttons can be replaced with the slot `opc-nav-btn`. Icon buttons with size of 60px are prefered. `activeMenu` property provides active class styling to show users which one is selected. It accepts `menu | notification` as value.
 
 | Name                | Icon      | Event                          |
 | ------------------- | --------- | ------------------------------ |
@@ -98,6 +98,7 @@ The nav buttons, enable utility actions that enhance the user experience. By def
 ```html
 <opc-nav>
   <img slot="opc-nav-logo" src="" alt="logo" />
+  <opc-nav-search slot="opc-nav-search"></opc-nav-search>
 </opc-nav>
 ```
 
@@ -108,7 +109,7 @@ The nav buttons, enable utility actions that enhance the user experience. By def
 ### Code (Search hidden and custom button)
 
 ```html
-<opc-nav isSearchHidden>
+<opc-nav>
   <img slot="opc-nav-logo" src="" alt="logo" />
   <button slot="opc-nav-btn">R</button>
 </opc-nav>
@@ -117,6 +118,36 @@ The nav buttons, enable utility actions that enhance the user experience. By def
 ### Screenshot
 
 ![Image of opc-nav-with logo](./docs/opc-nav-with-logo.png)
+
+</details>
+
+<details>
+<summary>opc-nav-search</summary>
+
+## Details
+
+`opc-nav-search` is a search component for the `opc-nav`. It enables modular control on how the search works. It has events `opc-nav-search:change` on input change and `opc-nav-search:search` on search submit.
+
+### Code (Default)
+
+```html
+<opc-nav>
+  <opc-nav-search slot="opc-nav-search"></opc-nav-search>
+</opc-nav>
+```
+
+```js
+document
+  .querySelector('opc-nav-search')
+  .addEventListener('opc-nav-search:change', function (event) {
+    console.log(event.detail.value);
+  });
+document
+  .querySelector('opc-nav-search')
+  .addEventListener('opc-nav-search:submit', function (event) {
+    console.log(event.detail.value);
+  });
+```
 
 </details>
 
@@ -148,17 +179,17 @@ There are total 4 slots of which 3 are optional and one is mandatory
 document.querySelector('opc-nav').links = [{ name: 'Blog', href: '#' }];
 ```
 
-- `isSearchHidden`
-  - Type: `Boolean`
-  - Default value: `false`
+- `activeButton`
+  - Type: `menu | notification`
+  - Default value: null
 
-```html
-<opc-nav isSearchHidden>
-  <img slot="opc-nav-logo" src="./logo.svg" height="28px" alt="logo" />
-</opc-nav>
+```js
+document.querySelector('opc-nav').activeMenu = 'menu';
 ```
 
 ## Events
+
+### opc-nav
 
 There are two events emitted by opc-nav both are dispatched on click of navbar notification(bell icon) and menu(grid icon) button.
 
@@ -187,6 +218,36 @@ document
   .querySelector('opc-nav')
   .addEventListener('opc-nav-btn-notification:click', function (event) {
     alert('notification got clicked');
+  });
+```
+
+### opc-nav-search
+
+1. `opc-nav-search:change`
+
+Dispatched on input change of search.
+
+Example:
+
+```js
+document
+  .querySelector('opc-nav-search')
+  .addEventListener('opc-nav-search:change', function (event) {
+    console.log(event.detail.value);
+  });
+```
+
+2. `opc-nav-btn-notification:click`
+
+Dispatched on notification(bell icon) button click.
+
+Example:
+
+```js
+document
+  .querySelector('opc-nav')
+  .addEventListener('opc-nav-search:submit', function (event) {
+    alert(event.detail.value);
   });
 ```
 

--- a/packages/opc-nav/declaration.d.ts
+++ b/packages/opc-nav/declaration.d.ts
@@ -4,3 +4,5 @@ interface OpcNavMenuLinks {
   name: string;
   href: string;
 }
+
+type Active = 'menu' | 'notification';

--- a/packages/opc-nav/demo/index.html
+++ b/packages/opc-nav/demo/index.html
@@ -24,14 +24,24 @@
         </h3>
         <opc-nav>
             <img slot="opc-nav-logo" src="./logo.svg" height="28px" alt="logo" />
+            <opc-nav-search slot="opc-nav-search" value="search"></opc-nav-search>
         </opc-nav>
     </div>
     <div class="seperate">
         <h3>
             Opc-Nav with hidden search and links
         </h3>
-        <opc-nav isSearchHidden>
+        <opc-nav>
             <img slot="opc-nav-logo" src="./logo.svg" height="28px" alt="logo" />
+        </opc-nav>
+    </div>
+    <div class="seperate">
+        <h3>
+            Opc-Nav with active menu
+        </h3>
+        <opc-nav activeButton="menu">
+            <img slot="opc-nav-logo" src="./logo.svg" height="28px" alt="logo" />
+            <opc-nav-search slot="opc-nav-search" value="search"></opc-nav-search>
         </opc-nav>
     </div>
     <script>
@@ -40,7 +50,13 @@
             { name: "Documentation", href: "#" }
         ];
         const opcNav = document.querySelector("opc-nav");
+        const opcNavSearch = document.querySelector("opc-nav-search");
         opcNav.links = links;
+
+        opcNavSearch.addEventListener('opc-nav-search:change', function (event) {
+            console.log(event.detail.value);
+        })
+
         opcNav.addEventListener('opc-nav-btn-menu:click', function (event) {
             alert("menu got clicked")
         });

--- a/packages/opc-nav/demo/opc-nav.stories.js
+++ b/packages/opc-nav/demo/opc-nav.stories.js
@@ -6,17 +6,12 @@ export default {
   parameters: {
     notes: { readme },
   },
-  argTypes: {
-    isSearchHidden: {
-      control: 'boolean',
-      description: 'To hide the searchbar',
-    },
-  },
 };
 
 export const opcNav = () => `
 <opc-nav>
     <img slot="opc-nav-logo" src="./logo.svg" height="28px" alt="logo" />
+    <opc-nav-search slot="opc-nav-search"></opc-nav-search>
 </opc-nav>
 <script>
 const links = [

--- a/packages/opc-nav/package-lock.json
+++ b/packages/opc-nav/package-lock.json
@@ -800,6 +800,12 @@
       "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.0.0-rc.2.tgz",
       "integrity": "sha512-cujeIl5Ei8FC7UHf4/4Q3bRJOtdTe1vpJV/JEBYCggedmQ+2P8A2oz7eE+Vxi6OJ4nc0X+KZxXnBoH4QrEbmEQ=="
     },
+    "@one-platform/opc-styles": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@one-platform/opc-styles/-/opc-styles-0.0.5.tgz",
+      "integrity": "sha512-/FeIXDx0KRsH+hrvOyB1mvI1XzQt7a1Nc8Q3WXQ84LD9UJp4OsF9jjqk5/AvrW90+gBlhhchWUJ8PtcQFxVhAg==",
+      "dev": true
+    },
     "@sindresorhus/is": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",

--- a/packages/opc-nav/src/opc-nav.scss
+++ b/packages/opc-nav/src/opc-nav.scss
@@ -23,9 +23,6 @@ input {
 }
 
 :host {
-  position: sticky;
-  top: 0;
-  left: 0;
   --opc-nav-height: 60px;
   --opc-nav-transition--default: 120ms ease-in-out;
   --opc-nav-menu__spacing-size: 24px;
@@ -33,6 +30,10 @@ input {
   --opc-nav-container__z-index: 9;
   --opc-nav-btn__padding: 17px;
   --opc-nav-btn__hover-color: #316dc11a;
+  position: sticky;
+  top: 0;
+  left: 0;
+  z-index: var(--opc-nav-container__z-index, 10);
 }
 
 .opc-nav {
@@ -41,7 +42,6 @@ input {
     font-family: var(--opc-global--Font-Family);
     align-items: center;
     border: 1px solid #dddddd;
-    z-index: var(--opc-nav-container__z-index, 9);
     background-color: #fff;
     height: var(--opc-nav-height);
   }
@@ -87,6 +87,7 @@ input {
     transition: var(--opc-nav-transition--default, 120ms ease-in-out);
     background: none;
 
+    &[active],
     &:hover {
       background: var(--opc-nav-btn__hover-color);
 
@@ -99,6 +100,7 @@ input {
 
   &-search__btn {
     padding: var(--opc-nav-btn__padding);
+    cursor: pointer;
   }
 
   &-search__input {
@@ -137,12 +139,15 @@ input {
     ::slotted(button:hover),
     button:hover,
     ::slotted(button:active),
-    button:active {
+    button:active,
+    ::slotted(button[active]),
+    button[active] {
       background: var(--opc-nav-btn__hover-color);
     }
 
     button:hover img,
-    button:active img {
+    button:active img,
+    button[active] img {
       filter: invert(42%) sepia(13%) saturate(5058%) hue-rotate(187deg)
         brightness(85%) contrast(85%);
     }

--- a/packages/opc-nav/src/opc-nav.ts
+++ b/packages/opc-nav/src/opc-nav.ts
@@ -1,5 +1,6 @@
 import { html, LitElement } from 'lit';
-import { customElement, property, state } from 'lit/decorators.js';
+import { customElement, property, query, state } from 'lit/decorators.js';
+import { live } from 'lit/directives/live.js';
 
 import { searchIcon, notificationIcon, gridIcon } from './assets';
 import style from './opc-nav.scss';
@@ -12,13 +13,7 @@ export class OpcNav extends LitElement {
 
   @property({ type: String }) name = 'opc-nav';
   @property({ type: Array, reflect: true }) links: OpcNavMenuLinks[] = [];
-  @property({ type: Boolean, reflect: true }) isSearchHidden: boolean = false;
-
-  @state() _isSearchOpen: boolean = false;
-
-  private _handleToggleSearch() {
-    this._isSearchOpen = !this._isSearchOpen;
-  }
+  @property({ type: String, reflect: true }) activeButton: Active | null = null;
 
   private _handleButtonClick(type: 'notification' | 'menu') {
     const name = `opc-nav-btn-${type}:click`;
@@ -44,54 +39,14 @@ export class OpcNav extends LitElement {
           </slot>
         </nav>
         <div class="flex-grow"></div>
-        ${this.isSearchHidden
-          ? ''
-          : html`
-              <slot name="opc-nav-search">
-                <div class="opc-nav-search">
-                  <form class="opc-nav-search__form" action="/search">
-                    ${this._isSearchOpen
-                      ? html` <button class="opc-nav-search__btn" type="submit">
-                          <img
-                            src="${searchIcon}"
-                            class="opc-nav__icon"
-                            alt="user"
-                            width="20px"
-                            height="20px"
-                          />
-                        </button>`
-                      : html` <button
-                          class="opc-nav-search__btn"
-                          type="button"
-                          @click="${this._handleToggleSearch}"
-                        >
-                          <img
-                            src="${searchIcon}"
-                            class="opc-nav__icon"
-                            alt="user"
-                            width="20px"
-                            height="20px"
-                          />
-                        </button>`}
-                    <input
-                      class="opc-nav-search__input ${this._isSearchOpen
-                        ? 'opc-nav-search__input-active'
-                        : ''}"
-                      type="search"
-                      name="query"
-                      autocomplete="off"
-                      aria-label="Search"
-                      placeholder="Search"
-                      required
-                      @blur="${this._handleToggleSearch}"
-                    />
-                  </form>
-                </div>
-              </slot>
-            `}
+        <slot></slot>
+        <slot name="opc-nav-search"> </slot>
         <div class="opc-nav-btn-container">
           <slot name="opc-nav-btn">
-            <button @click="${(e) => this._handleButtonClick('notification')}">
+            <button
+              @click="${(e) => this._handleButtonClick('notification')}"
+              ?active=${this.activeButton === 'notification'}
+            >
               <img
                 src="${notificationIcon}"
                 alt="icons"
@@ -99,7 +54,10 @@ export class OpcNav extends LitElement {
                 height="20px"
               />
             </button>
-            <button @click="${(e) => this._handleButtonClick('menu')}">
+            <button
+              @click="${(e) => this._handleButtonClick('menu')}"
+              ?active=${this.activeButton === 'menu'}
+            >
               <img
                 src="${gridIcon}"
                 alt="icons"
@@ -112,5 +70,110 @@ export class OpcNav extends LitElement {
         </div>
       </div>
     </header>`;
+  }
+}
+
+@customElement('opc-nav-search')
+export class OpcNavSearch extends LitElement {
+  static get styles() {
+    return [style];
+  }
+
+  @property({ type: String, reflect: true })
+  value = '';
+
+  @state()
+  private _isSearchOpen: boolean = false;
+
+  @query('input')
+  private input!: HTMLInputElement;
+
+  private _handleSearchOpen() {
+    this._isSearchOpen = true;
+    this.input.focus();
+  }
+
+  private _handleSearchClose() {
+    if (!this.input.value) {
+      this.value = '';
+      this._isSearchOpen = false;
+    }
+  }
+
+  private _handleInputChange(e: Event) {
+    this.dispatchEvent(
+      new CustomEvent('opc-nav-search:change', {
+        detail: {
+          value: this.input.value,
+        },
+      })
+    );
+  }
+
+  private _handleSearchSubmit(e: Event) {
+    e.preventDefault();
+    this.dispatchEvent(
+      new CustomEvent('opc-nav-search:submit', {
+        detail: {
+          value: this.input.value,
+        },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  render() {
+    const isSearchExpanded = Boolean(this.value) || this._isSearchOpen;
+
+    return html`
+      <div class="opc-nav-search">
+        <form
+          class="opc-nav-search__form"
+          @submit="${this._handleSearchSubmit}"
+          ?active=${isSearchExpanded}
+          @blur="${this._handleSearchClose}"
+        >
+          ${isSearchExpanded
+            ? html` <button class="opc-nav-search__btn" type="submit">
+                <img
+                  src="${searchIcon}"
+                  class="opc-nav__icon"
+                  alt="user"
+                  width="20px"
+                  height="20px"
+                />
+              </button>`
+            : html` <button
+                class="opc-nav-search__btn"
+                type="button"
+                @click="${this._handleSearchOpen}"
+              >
+                <img
+                  src="${searchIcon}"
+                  class="opc-nav__icon"
+                  alt="user"
+                  width="20px"
+                  height="20px"
+                />
+              </button>`}
+          <input
+            class="opc-nav-search__input ${isSearchExpanded
+              ? 'opc-nav-search__input-active'
+              : ''}"
+            type="search"
+            name="query"
+            autofocus
+            autocomplete="off"
+            aria-label="Search"
+            placeholder="Search"
+            required
+            .value=${live(this.value)}
+            @blur="${this._handleSearchClose}"
+            @input="${this._handleInputChange}"
+          />
+        </form>
+      </div>
+    `;
   }
 }

--- a/packages/opc-nav/test/opc-nav.test.ts
+++ b/packages/opc-nav/test/opc-nav.test.ts
@@ -1,5 +1,5 @@
 import { axe, toHaveNoViolations } from 'jest-axe';
-import { OpcNav } from '../src/opc-nav';
+import { OpcNav, OpcNavSearch } from '../src/opc-nav';
 
 expect.extend(toHaveNoViolations);
 
@@ -36,11 +36,38 @@ describe('opc-nav', () => {
     expect(opcNav.links[0].name).toEqual('Blog');
     expect(opcNav.links[0].href).toEqual('#');
   });
+});
 
-  it('should make search hidden', async () => {
-    expect(opcNav.isSearchHidden).toBeFalsy();
-    opcNav.isSearchHidden = true;
-    await opcNav.updateComplete;
-    expect(opcNav.isSearchHidden).toBeTruthy();
+describe('opc-nav-search', () => {
+  const OPC_COMPONENT = 'opc-nav-search';
+  const ELEMENT_ID = 'opc-nav-search';
+  let opcNavSearch: OpcNavSearch;
+
+  const getShadowRoot = (tagName: string): ShadowRoot => {
+    return document.body.getElementsByTagName(tagName)[0].shadowRoot;
+  };
+
+  beforeEach(() => {
+    opcNavSearch = window.document.createElement(OPC_COMPONENT) as OpcNavSearch;
+    document.body.appendChild(opcNavSearch);
+  });
+
+  afterEach(() => {
+    document.body.getElementsByTagName(OPC_COMPONENT)[0].remove();
+  });
+
+  it('is defined', async () => {
+    expect(opcNavSearch).toBeDefined();
+  });
+
+  it('has no axe violations', async () => {
+    expect(await axe(opcNavSearch)).toHaveNoViolations();
+  });
+
+  it('should change value', async () => {
+    expect(opcNavSearch.value).toEqual('');
+    opcNavSearch.value = 'search';
+    await opcNavSearch.updateComplete;
+    expect(opcNavSearch.value).toEqual('search');
   });
 });


### PR DESCRIPTION
# Fixes

1109

# Explain the feature/fix

1. Implemented opc-nav-search component for opc-nav, by decoupling it from  its search component. This helps keeping the component atomic and also ease to control the search action.
2. Added another property `activeButton` to control which default nav button is active.
3. Updated test and added new one for opc-nav-search.
4. Updated documentation.

## Does this PR introduce a breaking change

Yes

## Screenshots

<details>
<summary>View Screenshots</summary>

<img width="724" alt="Screenshot 2021-08-05 at 10 07 06 PM" src="https://user-images.githubusercontent.com/31166322/128388994-0dcbe238-5d0d-42c9-b64c-fd1b3aeb6e4c.png">

</details>

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Does the change have appropriate unit tests?
- [x] Did tests pass?
- [x] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code
- [x] I have documented my code, particularly in areas like todo, complex logic, quick fix, temporary patch, etc.
#### If it is a new component
- [x] Does your component follow One Platform style guidelines?
- [x] Does your component web accessibility standards? [Helper Doc](https://www.w3.org/TR/wai-aria-1.1/)
- [x] Does your component support desktop screen sizes (350px, 720px, 1150px ,1920px)
#### Browsers you have tested in
- [ ] Latest two versions of Mozilla Firefox and Google Chrome supported by Red Hat Enterprise Linux distribution
- [x] Google Chrome [Latest 2 versions]
- [x] Mozilla Firefox [Latest 2 versions]
- [ ] Microsoft Edge [Latest 2 versions]
- [x] Apple Safari [Latest 2 versions]
- [ ] Microsoft Internet Explorer 11
