### PR TITLE
hotfix: fixed opc-nav zindex not working in new chrome

### DIFF
--- a/packages/opc-nav/src/opc-nav.scss
+++ b/packages/opc-nav/src/opc-nav.scss
@@ -37,6 +37,9 @@ input {
 }
 
 .opc-nav {
+  z-index: var(--opc-nav-container__z-index, 10);
+  position: relative;
+
   &-container {
     display: flex;
     font-family: var(--opc-global--Font-Family);


### PR DESCRIPTION
# Closes/Fixes/Resolves

1. Fixes opc-nav zindex not working in latest chrome

# Explain the feature/fix

1. opc-nav zindex not working in chrome, which makes it not going behind of opc drawer

## Does this PR introduce a breaking change

No

## Screenshots

<details>
<summary>View Screenshots</summary>

![image](https://user-images.githubusercontent.com/31166322/130200496-8e3e24bf-aeef-48d6-abbe-1eab17aefab9.png)

</details>

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Does the change have appropriate unit tests?
- [x] Did tests pass?
- [x] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code
- [x] I have documented my code, particularly in areas like todo, complex logic, quick fix, temporary patch, etc.
#### If it is a new component
- [x] Does your component follow One Platform style guidelines?
- [x] Does your component web accessibility standards? [Helper Doc](https://www.w3.org/TR/wai-aria-1.1/)
- [x] Does your component support desktop screen sizes (350px, 720px, 1150px ,1920px)
#### Browsers you have tested in
- [x] Latest two versions of Mozilla Firefox and Google Chrome supported by Red Hat Enterprise Linux distribution
- [x] Google Chrome [Latest 2 versions]
- [x] Mozilla Firefox [Latest 2 versions]
- [ ] Microsoft Edge [Latest 2 versions]
- [ ] Apple Safari [Latest 2 versions]
- [ ] Microsoft Internet Explorer 11
