### PR TITLE
feat(1488): opc-nav position fixed to top in chrome

### DIFF
--- a/packages/opc-nav/README.md
+++ b/packages/opc-nav/README.md
@@ -256,12 +256,16 @@ document
 | CSS Variable name               | Value             |
 | ------------------------------- | ----------------- |
 | `--opc-nav-height`              | 60px              |
+| ` --opc-nav-width`              | 100%              |
+| ` --opc-nav-position-top`       | 0                 |
+| ` --opc-nav-position-left`      | 0                 |
 | ` --opc-nav-transition--defaul` | 120ms ease-in-out |
 | `--opc-nav-menu__spacing-size`  | 24px              |
 | `--opc-nav-menu__link-color`    | #151515           |
 | ` --opc-nav-container__z-index` | 9                 |
 | `--opc-nav-btn__padding`        | 16px              |
 | ` --opc-nav-btn__hover-color`   | #316dc11a         |
+| ` --opc-nav-display;`           | block             |
 
 ## Install
 

--- a/packages/opc-nav/demo/index.html
+++ b/packages/opc-nav/demo/index.html
@@ -10,39 +10,21 @@
         @import url("https://fonts.googleapis.com/css2?family=Red+Hat+Text&display=swap");
         @import url("https://fonts.googleapis.com/css2?family=Red+Hat+Display&display=swap");
 
-
-        .seperate {
-            padding: 1rem 0;
+        .content {
+            height: 200vh;
         }
     </style>
 </head>
 
 <body>
-    <div class="seperate">
-        <h3>
-            Opc-Nav
-        </h3>
+    <div>
         <opc-nav>
             <img slot="opc-nav-logo" src="./logo.svg" height="28px" alt="logo" />
             <opc-nav-search slot="opc-nav-search" value="search"></opc-nav-search>
         </opc-nav>
-    </div>
-    <div class="seperate">
-        <h3>
-            Opc-Nav with hidden search and links
-        </h3>
-        <opc-nav>
-            <img slot="opc-nav-logo" src="./logo.svg" height="28px" alt="logo" />
-        </opc-nav>
-    </div>
-    <div class="seperate">
-        <h3>
-            Opc-Nav with active menu
-        </h3>
-        <opc-nav activeButton="menu">
-            <img slot="opc-nav-logo" src="./logo.svg" height="28px" alt="logo" />
-            <opc-nav-search slot="opc-nav-search" value="search"></opc-nav-search>
-        </opc-nav>
+        <div class="content">
+            This is content
+        </div>
     </div>
     <script>
         const links = [

--- a/packages/opc-nav/package.json
+++ b/packages/opc-nav/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@one-platform/opc-nav",
-  "version": "0.0.1-prerelease",
+  "version": "0.0.2-prerelease",
   "description": "opc-nav is a nav bar component developed using lit elements for Red Hat One Platform.",
   "scripts": {
     "dev": "webpack serve",

--- a/packages/opc-nav/src/opc-nav-search.scss
+++ b/packages/opc-nav/src/opc-nav-search.scss
@@ -1,0 +1,65 @@
+@import '@one-platform/opc-styles';
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+ul,
+button,
+input {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  outline: 0;
+  font-weight: inherit;
+  vertical-align: baseline;
+  background: none;
+}
+
+.opc-nav {
+  &-search {
+    &__form {
+      display: flex;
+      align-items: center;
+      transition: var(--opc-nav-transition--default, 120ms ease-in-out);
+      background: none;
+
+      &[active],
+      &:hover {
+        background: var(--opc-nav-btn__hover-color);
+
+        img {
+          filter: invert(42%) sepia(13%) saturate(5058%) hue-rotate(187deg)
+            brightness(85%) contrast(85%);
+        }
+      }
+    }
+
+    &__btn {
+      padding: var(--opc-nav-btn__padding);
+      cursor: pointer;
+    }
+
+    &__input {
+      font-family: var(--opc-global--Heading--Font-Family);
+      font-size: 16px;
+      width: 0;
+      opacity: 0;
+      transition: var(--opc-nav-transition--default, 120ms ease-in-out);
+      outline: none;
+
+      &:required {
+        box-shadow: none;
+      }
+
+      &-active {
+        opacity: 1;
+        width: 20vw;
+        max-width: 360px;
+        padding-right: 20px;
+      }
+    }
+  }
+}

--- a/packages/opc-nav/src/opc-nav.scss
+++ b/packages/opc-nav/src/opc-nav.scss
@@ -23,22 +23,30 @@ input {
 }
 
 :host {
+  --opc-nav-display: block;
+  --opc-nav-position: fixed;
+  --opc-nav-position-top: 0;
+  --opc-nav-position-left: 0;
   --opc-nav-height: 60px;
+  --opc-nav-width: 100%;
   --opc-nav-transition--default: 120ms ease-in-out;
   --opc-nav-menu__spacing-size: 24px;
   --opc-nav-menu__link-color: #151515;
   --opc-nav-container__z-index: 9;
   --opc-nav-btn__padding: 17px;
   --opc-nav-btn__hover-color: #316dc11a;
-  position: sticky;
-  top: 0;
-  left: 0;
-  z-index: var(--opc-nav-container__z-index, 10);
+  display: var(--opc-nav-display, block);
+  height: var(--opc-nav-height, 60px);
 }
 
 .opc-nav {
   z-index: var(--opc-nav-container__z-index, 10);
-  position: relative;
+  position: var(--opc-nav-position, fixed);
+  height: var(--opc-nav-height, 60px);
+  width: var(--opc-nav-width, 100%);
+  top: var(--opc-nav-position-top, 0);
+  left: var(--opc-nav-position-left, 0);
+  z-index: var(--opc-nav-container__z-index, 10);
 
   &-container {
     display: flex;
@@ -82,48 +90,6 @@ input {
     border: 0;
     background: none;
     cursor: pointer;
-  }
-
-  &-search__form {
-    display: flex;
-    align-items: center;
-    transition: var(--opc-nav-transition--default, 120ms ease-in-out);
-    background: none;
-
-    &[active],
-    &:hover {
-      background: var(--opc-nav-btn__hover-color);
-
-      img {
-        filter: invert(42%) sepia(13%) saturate(5058%) hue-rotate(187deg)
-          brightness(85%) contrast(85%);
-      }
-    }
-  }
-
-  &-search__btn {
-    padding: var(--opc-nav-btn__padding);
-    cursor: pointer;
-  }
-
-  &-search__input {
-    font-family: var(--opc-global--Heading--Font-Family);
-    font-size: 16px;
-    width: 0;
-    opacity: 0;
-    transition: var(--opc-nav-transition--default, 120ms ease-in-out);
-    outline: none;
-
-    &:required {
-      box-shadow: none;
-    }
-
-    &-active {
-      opacity: 1;
-      width: 20vw;
-      max-width: 360px;
-      padding-right: 20px;
-    }
   }
 
   &-btn-container {

--- a/packages/opc-nav/src/opc-nav.ts
+++ b/packages/opc-nav/src/opc-nav.ts
@@ -3,12 +3,13 @@ import { customElement, property, query, state } from 'lit/decorators.js';
 import { live } from 'lit/directives/live.js';
 
 import { searchIcon, notificationIcon, gridIcon } from './assets';
-import style from './opc-nav.scss';
+import opcNavStyle from './opc-nav.scss';
+import opcNavSearchStyle from './opc-nav-search.scss';
 
 @customElement('opc-nav')
 export class OpcNav extends LitElement {
   static get styles() {
-    return [style];
+    return [opcNavStyle];
   }
 
   @property({ type: String }) name = 'opc-nav';
@@ -76,7 +77,7 @@ export class OpcNav extends LitElement {
 @customElement('opc-nav-search')
 export class OpcNavSearch extends LitElement {
   static get styles() {
-    return [style];
+    return [opcNavSearchStyle];
   }
 
   @property({ type: String, reflect: true })


### PR DESCRIPTION
# Resolves

1488

# Explain the feature/fix

1. Fixed opc-nav not getting position fix to top in chrome
2. Updated readme

## Does this PR introduce a breaking change
No

## Screenshots

<!-- If applicable, add screenshots/gif to help explain your problem. -->

<details>
<summary>View Screenshots</summary>

| Description |  Screenshot |
| ----------- | ------------ |
| On first render with overflow |  ![Screenshot 2021-09-20 at 10 53 22 PM](https://user-images.githubusercontent.com/31166322/134046749-8e4f5cc8-cb24-41c1-b3d0-55f0e19349b5.png) |
| On scroll | ![Screenshot 2021-09-20 at 10 53 31 PM](https://user-images.githubusercontent.com/31166322/134046829-e13de500-5547-47ff-b3ca-abc552dbfbf9.png) |

</details>

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Does the change have appropriate unit tests?
- [x] Did tests pass?
- [x] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code
- [x] I have documented my code, particularly in areas like todo, complex logic, quick fix, temporary patch, etc.
#### If it is a new component
- [x] Does your component follow One Platform style guidelines?
- [x] Does your component web accessibility standards? [Helper Doc](https://www.w3.org/TR/wai-aria-1.1/)
- [x] Does your component support desktop screen sizes (350px, 720px, 1150px ,1920px)
#### Browsers you have tested in
- [x] Latest two versions of Mozilla Firefox and Google Chrome supported by Red Hat Enterprise Linux distribution
- [x] Google Chrome [Latest 2 versions]
- [x] Mozilla Firefox [Latest 2 versions]
- [x] Microsoft Edge [Latest 2 versions]
- [ ] Apple Safari [Latest 2 versions]
- [ ] Microsoft Internet Explorer 11
