### PR TITLE
opc-feedback - change property type of app from 'Object' to 'String'

### DIFF
--- a/packages/opc-feedback/README.md
+++ b/packages/opc-feedback/README.md
@@ -81,7 +81,7 @@ import '@one-platform/opc-feedback/dist/opc-feedback';
 |---------|------------------------------------------------------------------|
 | ```spa``` | ```String``` value is expected ```/feedback``` is the default fallback url for feedback spa |
 | ```docs``` | ```String``` value is expected ```/get-started``` is the default fallback url for docs |
-| ```app``` | ```Object``` value is expected ```{ name: 'one platform', url: '/' }``` is the default fallback url for docs |
+| ```app``` | ```String``` value is expected in json format ```'{ "name": "one platform", "url": "/" }'``` is the default fallback url for docs |
 | ```theme``` | Refer [themes](https://github.com/1-Platform/op-components/tree/master/packages/opc-feedback/README.md#themes) section. |
 
 

--- a/packages/opc-feedback/src/opc-feedback.ts
+++ b/packages/opc-feedback/src/opc-feedback.ts
@@ -31,7 +31,7 @@ export class OpcFeedback extends LitElement {
   @property({ type: String, attribute: 'docs' }) docs = '/get-started';
   @property({ reflect: true }) theme = 'red';
   @property({ type: Object }) template = defaultTemplate;
-  @property({ type: Object }) app = defaultApplication;
+  @property({ type: String }) app = `{"name": "${defaultApplication.name}" ,"url":"${defaultApplication.url}"}`;
   @state()
   _openConfirmationModal = false;
   @state()
@@ -189,6 +189,7 @@ export class OpcFeedback extends LitElement {
   }
 
   render() {
+    const app = JSON.parse(this.app);
     this._updateTemplate();
     return html`
       <!-- Bug Panel -->
@@ -279,8 +280,8 @@ export class OpcFeedback extends LitElement {
         </form>
         <p class="pf-u-font-size-xs">
           Bug reporting for
-          <a href="${this.app.url}" target="_blank" rel="noopener noreferrer">
-            ${this.app.name}
+          <a href="${app.url}" target="_blank" rel="noopener noreferrer">
+            ${app.name}
           </a>
         </p>
       </dialog>
@@ -385,8 +386,8 @@ export class OpcFeedback extends LitElement {
         </form>
         <p class="pf-u-font-size-xs">
           Feedback for
-          <a href="${this.app.url}" target="_blank" rel="noopener noreferrer">
-            ${this.app.name}
+          <a href="${app.url}" target="_blank" rel="noopener noreferrer">
+            ${app.name}
           </a>
         </p>
       </dialog>


### PR DESCRIPTION
<!--
Follow the steps to create the PR:

Subject: "feat/fix/docs(#issue_id): <PR Subject>"
Assignees: "One Platform Developers"
-->

# Fixes
**Fixed `Cannot read properties of null (reading 'url')`**

# Explain the fix
The `app` attribute for html element only accepts string, so its better  to accept json in string format
and then parse it with help of `JSON.parse();`


## Does this PR introduce a breaking change
No

## Screenshots

<!-- If applicable, add screenshots/gif to help explain your problem. -->

<details>
<summary>Before Screenshots</summary>

![image](https://github.com/1-Platform/op-components/assets/42431299/60eccfc7-a895-4eb2-86ef-19a90b5abdc9)

![image](https://github.com/1-Platform/op-components/assets/42431299/2fc476a0-ef35-48ab-8814-4d65b0c2b08b)
</details>
<details>
<summary>After Screenshots</summary>

![image](https://github.com/1-Platform/op-components/assets/42431299/60eccfc7-a895-4eb2-86ef-19a90b5abdc9)

![image](https://github.com/1-Platform/op-components/assets/42431299/cd833622-959b-4478-b0ef-26d34b79a41b)
</details>

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [ ] Does the change have appropriate unit tests?
- [ ] Did tests pass?
- [x] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code
- [ ] I have documented my code, particularly in areas like todo, complex logic, quick fix, temporary patch, etc.
#### Browsers you have tested in
- [x] Latest two versions of Mozilla Firefox and Google Chrome supported by Red Hat Enterprise Linux distribution
- [ ] Google Chrome [Latest 2 versions]
- [ ] Mozilla Firefox [Latest 2 versions]
- [ ] Microsoft Edge [Latest 2 versions]
- [ ] Apple Safari [Latest 2 versions]
- [ ] Microsoft Internet Explorer 11
